### PR TITLE
refactor: reduce state complexity

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-leaflet-supercluster",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "React wrapper for the supercluster library",
   "repository": "https://github.com/TurtIeSocks/react-leaflet-supercluster",
   "author": "TurtIeSocks <58572875+TurtIeSocks@users.noreply.github.com>",

--- a/src/SuperClustering.tsx
+++ b/src/SuperClustering.tsx
@@ -77,7 +77,5 @@ export function SuperClustering({
     disableZoomEvent,
   ])
 
-  return superCluster
-    ? normalizedChildren.filter((x, i) => markerFilter(x, i, markers))
-    : normalizedChildren
+  return normalizedChildren.filter((x, i) => markerFilter(x, i, markers))
 }

--- a/src/useSuperClustering.ts
+++ b/src/useSuperClustering.ts
@@ -16,19 +16,20 @@ export function useSuperClustering({
 }: Options<GeoJsonProperties, GeoJsonProperties>): InstanceType<
   typeof Supercluster
 > {
-  const options = useMemo(
-    () => ({
-      minPoints,
-      minZoom,
-      maxZoom,
-      extent,
-      generateId,
-      log,
-      map,
-      nodeSize,
-      radius,
-      reduce,
-    }),
+  const superCluster = useMemo(
+    () =>
+      new Supercluster({
+        minPoints,
+        minZoom,
+        maxZoom,
+        extent,
+        generateId,
+        log,
+        map,
+        nodeSize,
+        radius,
+        reduce,
+      }),
     [
       minPoints,
       minZoom,
@@ -42,11 +43,5 @@ export function useSuperClustering({
       reduce,
     ]
   )
-  const [superCluster, setSuperCluster] = useState(new Supercluster(options))
-
-  useEffect(() => {
-    setSuperCluster(new Supercluster(options))
-  }, [options])
-
   return superCluster
 }


### PR DESCRIPTION
- Incredibly unnecessary to have a useEffect, useState, and useMemo